### PR TITLE
Upgrade just to 1.52.0

### DIFF
--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -1,4 +1,4 @@
 [tools]
-just = "1.45.0"
+just = "1.52.0"
 node = "24.11.1"
 "npm:strip-ansi-cli" = "4.0.0"


### PR DESCRIPTION
Bumps the pinned `just` version to 1.52.0 in `.mise/config.toml` to match the project-template baseline.